### PR TITLE
Fix cleanup policy methods in Ops::Backup model

### DIFF
--- a/lib/ops_backups/version.rb
+++ b/lib/ops_backups/version.rb
@@ -1,3 +1,3 @@
 module OpsBackups
-  VERSION = "0.1.9"
+  VERSION = "0.1.10"
 end


### PR DESCRIPTION
The cleanup methods in the `Ops::Backup` model where actually outside the model definition, so they weren't properly called by the backup job.

I've also removed a couple of test methods from the class - I assume they're not really needed.